### PR TITLE
Enable natural language company search

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The Flask application in `app.py` exposes the features of `search.py` through a 
 ### Install dependencies
 
 ```bash
-pip install flask flask-cors werkzeug itsdangerous requests beautifulsoup4
+pip install flask flask-cors werkzeug itsdangerous requests beautifulsoup4 spacy torch transformers
+python -m spacy download fr_core_news_sm
 ```
 
 ### Run the API
@@ -24,7 +25,8 @@ The API will create a local `app.db` SQLite database. Endpoints:
 
 - `POST /api/register` with JSON `{username, email, password}`
 - `POST /api/login` with JSON `{email, password}` returns a token
-- `GET /api/search?domain=example.com` authenticated with header `Authorization: Bearer <token>`
+- `GET /api/search?q=coiffeur+paris` authenticated with header `Authorization: Bearer <token>`
+  The `q` parameter accepts either a domain name or a short French phrase like `"esthéticienne vaucluse"`.
 
 ## Frontend
 
@@ -43,7 +45,7 @@ npm install
 npm run dev
 ```
 
-The app provides a login/registration screen and, once logged in, a small interface to search for companies by domain.
+The app provides a login/registration screen and, once logged in, a small interface to search for companies by domain or free text.
 
 ### API configuration
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -78,12 +78,12 @@ function Register({onRegister, switchToLogin}){
 }
 
 function Search({token,username}){
-  const [domain,setDomain]=useState('');
+  const [query,setQuery]=useState('');
   const [results,setResults]=useState([]);
   const [name,setName]=useState('');
   const search=async(e)=>{
     e.preventDefault();
-    const params=new URLSearchParams({domain});
+    const params=new URLSearchParams({q: query});
     const r=await fetch(`${API}/api/search?`+params.toString(),{headers:{'Authorization':'Bearer '+token}});
     if(r.ok){
       const data=await r.json();
@@ -96,7 +96,7 @@ function Search({token,username}){
       <h2>Welcome {username}</h2>
       <form onSubmit={search} className="mb-3">
         <div className="input-group">
-          <input className="form-control" placeholder="Domain" value={domain} onChange={e=>setDomain(e.target.value)} />
+          <input className="form-control" placeholder="Domain or search phrase" value={query} onChange={e=>setQuery(e.target.value)} />
           <button className="btn btn-success">Search</button>
         </div>
       </form>


### PR DESCRIPTION
## Summary
- parse French search phrases with a lightweight NLP model
- allow `/api/search` to accept `q` parameter for text or domain
- update CLI to accept text queries
- adjust React frontend for the new search field
- document new dependencies and usage

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68498ba6b8a08326b0eda2a998fcb231